### PR TITLE
Hotfix/fix cache clear

### DIFF
--- a/enable-media-replace.php
+++ b/enable-media-replace.php
@@ -3,8 +3,8 @@
 Plugin Name: Enable Media Replace
 Plugin URI: http://www.mansjonasson.se/enable-media-replace
 Description: Enable replacing media files by uploading a new file in the "Edit Media" section of the WordPress Media Library.
-Version: 2.9.3
-Author: Måns Jonasson
+Version: 2.9.3-BU-1.2
+Author: Måns Jonasson and BU IS&T
 Author URI: http://www.mansjonasson.se
 
 Dual licensed under the MIT and GPL licenses:

--- a/upload.php
+++ b/upload.php
@@ -267,7 +267,12 @@ if (is_uploaded_file($_FILES["userfile"]["tmp_name"])) {
 		update_attached_file( (int) $_POST["ID"], $new_file);
 		
 		if(function_exists('bu_clean_post_cache_single')){
-			bu_clean_post_cache_single( (int) $_POST["ID"] );
+			// BU Cache expects a post object, but only uses ID and post_type.  Don't bother fetching the full post object, just make a new object to pass to BU Cache.
+			$post_obj = new stdClass;
+			$post_obj->ID = $_POST["ID"];
+			$post_obj->post_type = 'attachment';
+
+			bu_clean_post_cache_single($post_obj);
 		}
 	}
 

--- a/upload.php
+++ b/upload.php
@@ -123,7 +123,7 @@ function emr_perform_rewrites($rewrites, $table_name) {
 		$to_list[] = $path_to;
 	}
 	
-	$sql = "SELECT ID, post_content FROM $table_name WHERE " . implode(' OR ', $likes);
+	$sql = "SELECT ID, post_content, post_type FROM $table_name WHERE " . implode(' OR ', $likes);
 	
 	$results = $wpdb->get_results($sql, ARRAY_A);
 
@@ -137,10 +137,17 @@ function emr_perform_rewrites($rewrites, $table_name) {
 		if ($replacements) {
 			$post_content = esc_sql($post_content);
 			$wpdb->query(sprintf("UPDATE $table_name SET post_content = '%s' WHERE ID = %d", $post_content, $row['ID']));
+
+			// Clear the post cache for the rewritten post.
+			if(function_exists('bu_clean_post_cache_single')){
+				// BU Cache expects a post object with an ID and post_type.
+				$row_obj = new stdClass;
+				$row_obj->ID = $row['ID'];
+				$row_obj->post_type = $row['post_type'];
+
+				bu_clean_post_cache_single($row_obj);
+			}
 		}
-	}
-	if(function_exists('bu_clean_post_cache_single')){
-		bu_clean_post_cache_single($row['ID']);
 	}
 }
 


### PR DESCRIPTION
It looks like the cache clearing functions have been non-functional for some time.  Because 4.6 uses name based permalinks instead of attachment ID based permalinks for media library items, the issue became apparent.

BU cache expects a post object with `ID` and `post_type` properties.  Enable Media Replace has been passing just the post ID.

Also, for posts that have rewritten post_content, the cache clearing call was outside the loop that processes the posts.

This PR fixes these problems so BU Cache can properly clear caches on updated posts and attachments.