### PR TITLE
Dfct2000208/filenames

### DIFF
--- a/enable-media-replace.php
+++ b/enable-media-replace.php
@@ -28,7 +28,7 @@ Developed for .SE (Stiftelsen för Internetinfrastruktur) - http://www.iis.se
 define('EMR_METHOD_REPLACE',                        1);
 define('EMR_METHOD_REPLACE_AND_RENAME',             2);
 define('EMR_METHOD_BOTH',                           3);
-define('EMR_METHOD',    EMR_METHOD_REPLACE_AND_RENAME);
+define('EMR_METHOD',    EMR_METHOD_BOTH);
 
 add_action('admin_init', 'enable_media_replace_init');
 add_action('admin_menu', 'emr_menu');

--- a/enable-media-replace.php
+++ b/enable-media-replace.php
@@ -3,7 +3,7 @@
 Plugin Name: Enable Media Replace
 Plugin URI: http://www.mansjonasson.se/enable-media-replace
 Description: Enable replacing media files by uploading a new file in the "Edit Media" section of the WordPress Media Library.
-Version: 2.9.3-BU-1.2
+Version: 2.9.3-BU-1.3
 Author: Måns Jonasson and BU IS&T
 Author URI: http://www.mansjonasson.se
 

--- a/enable-media-replace.php
+++ b/enable-media-replace.php
@@ -28,7 +28,7 @@ Developed for .SE (Stiftelsen för Internetinfrastruktur) - http://www.iis.se
 define('EMR_METHOD_REPLACE',                        1);
 define('EMR_METHOD_REPLACE_AND_RENAME',             2);
 define('EMR_METHOD_BOTH',                           3);
-define('EMR_METHOD',    EMR_METHOD_BOTH);
+define('EMR_METHOD',    EMR_METHOD_REPLACE);
 
 add_action('admin_init', 'enable_media_replace_init');
 add_action('admin_menu', 'emr_menu');

--- a/popup.php
+++ b/popup.php
@@ -2,8 +2,8 @@
 /**
  * Uploadscreen for selecting and uploading new media file
  *
- * @author      Måns Jonasson  <http://www.mansjonasson.se>
- * @copyright   Måns Jonasson 13 sep 2010
+ * @author      Mï¿½ns Jonasson  <http://www.mansjonasson.se>
+ * @copyright   Mï¿½ns Jonasson 13 sep 2010
  * @version     $Revision: 2303 $ | $Date: 2010-09-13 11:12:35 +0200 (ma, 13 sep 2010) $
  * @package     wordpress
  * @subpackage  enable-media-replace
@@ -50,21 +50,9 @@ $method = defined('EMR_METHOD') ? EMR_METHOD : EMR_METHOD_BOTH;
 
 		<input type="file" name="userfile" />
 
-	<?php if ($method == EMR_METHOD_BOTH): ?>
-		<p><?php echo __("Select media replacement type:", "enable-media-replace"); ?></p>
-
-		<label for="replace_type_1"><input CHECKED id="replace_type_1" type="radio" name="replace_type" value="replace"> <?php echo __("Just replace the file", "enable-media-replace"); ?></label>
-		<p class="howto"><?php echo __("Note: This option requires you to upload a file of the same type (", "enable-media-replace"); ?><?php echo $current_filetype; ?><?php echo __(") as the one you are replacing. The name of the attachment will stay the same (", "enable-media-replace"); ?><?php echo $current_filename; ?><?php echo __(") no matter what the file you upload is called.", "enable-media-replace"); ?></p>
-
-		<label for="replace_type_2"><input id="replace_type_2" type="radio" name="replace_type" value="replace_and_search"> <?php echo __("Replace the file, use new file name and update all links", "enable-media-replace"); ?></label>
-		<p class="howto"><?php echo __("Note: If you check this option, the name and type of the file you are about to upload will replace the old file. All links pointing to the current file (", "enable-media-replace"); ?><?php echo $current_filename; ?><?php echo __(") will be updated to point to the new file name.", "enable-media-replace"); ?></p>
-	<?php elseif ($method == EMR_METHOD_REPLACE): ?>
+		<input id="replace_type" type="hidden" name="replace_type" value="replace">
 		<p><?php echo __("<strong>Replacement method:</strong> ", "enable-media-replace");  echo __("Just replace the file", "enable-media-replace"); ?></p>
 		<p class="howto"><?php echo __("Note: This method requires you to upload a file of the same type (", "enable-media-replace"); ?><?php echo $current_filetype; ?><?php echo __(") as the one you are replacing. The name of the attachment will stay the same (", "enable-media-replace"); ?><?php echo $current_filename; ?><?php echo __(") no matter what the file you upload is called.", "enable-media-replace"); ?></p>
-	<?php elseif ($method == EMR_METHOD_REPLACE_AND_RENAME): ?>
-		<p><?php echo __("<strong>Replacement method:</strong> ", "enable-media-replace");  echo __("Replace the file, use new file name and update all links", "enable-media-replace"); ?></label>
-		<p class="howto"><?php echo __("Note: If you check this option, the name and type of the file you are about to upload will replace the old file. All links pointing to the current file (", "enable-media-replace"); ?><?php echo $current_filename; ?><?php echo __(") will be updated to point to the new file name.", "enable-media-replace"); ?></p>
-	<?php endif;?>
 
 		<input type="submit" class="button" value="<?php echo __("Upload", "enable-media-replace"); ?>" /> <a href="#" onclick="history.back();"><?php echo __("Cancel", "enable-media-replace"); ?></a>
 

--- a/popup.php
+++ b/popup.php
@@ -50,9 +50,22 @@ $method = defined('EMR_METHOD') ? EMR_METHOD : EMR_METHOD_BOTH;
 
 		<input type="file" name="userfile" />
 
-		<input id="replace_type" type="hidden" name="replace_type" value="replace">
+	<?php if ($method == EMR_METHOD_BOTH): ?>
+		<p><?php echo __("Select media replacement type:", "enable-media-replace"); ?></p>
+
+		<label for="replace_type_1"><input CHECKED id="replace_type_1" type="radio" name="replace_type" value="replace"> <?php echo __("Just replace the file", "enable-media-replace"); ?></label>
+		<p class="howto"><?php echo __("Note: This option requires you to upload a file of the same type (", "enable-media-replace"); ?><?php echo $current_filetype; ?><?php echo __(") as the one you are replacing. The name of the attachment will stay the same (", "enable-media-replace"); ?><?php echo $current_filename; ?><?php echo __(") no matter what the file you upload is called.", "enable-media-replace"); ?></p>
+
+		<label for="replace_type_2"><input id="replace_type_2" type="radio" name="replace_type" value="replace_and_search"> <?php echo __("Replace the file, use new file name and update all links", "enable-media-replace"); ?></label>
+		<p class="howto"><?php echo __("Note: If you check this option, the name and type of the file you are about to upload will replace the old file. All links pointing to the current file (", "enable-media-replace"); ?><?php echo $current_filename; ?><?php echo __(") will be updated to point to the new file name.", "enable-media-replace"); ?></p>
+	<?php elseif ($method == EMR_METHOD_REPLACE): ?>
+		<input id="replace_type_1" type="hidden" name="replace_type" value="replace">
 		<p><?php echo __("<strong>Replacement method:</strong> ", "enable-media-replace");  echo __("Just replace the file", "enable-media-replace"); ?></p>
 		<p class="howto"><?php echo __("Note: This method requires you to upload a file of the same type (", "enable-media-replace"); ?><?php echo $current_filetype; ?><?php echo __(") as the one you are replacing. The name of the attachment will stay the same (", "enable-media-replace"); ?><?php echo $current_filename; ?><?php echo __(") no matter what the file you upload is called.", "enable-media-replace"); ?></p>
+	<?php elseif ($method == EMR_METHOD_REPLACE_AND_RENAME): ?>
+		<p><?php echo __("<strong>Replacement method:</strong> ", "enable-media-replace");  echo __("Replace the file, use new file name and update all links", "enable-media-replace"); ?></label>
+		<p class="howto"><?php echo __("Note: If you check this option, the name and type of the file you are about to upload will replace the old file. All links pointing to the current file (", "enable-media-replace"); ?><?php echo $current_filename; ?><?php echo __(") will be updated to point to the new file name.", "enable-media-replace"); ?></p>
+	<?php endif;?>
 
 		<input type="submit" class="button" value="<?php echo __("Upload", "enable-media-replace"); ?>" /> <a href="#" onclick="history.back();"><?php echo __("Cancel", "enable-media-replace"); ?></a>
 

--- a/upload.php
+++ b/upload.php
@@ -206,6 +206,9 @@ if (is_uploaded_file($_FILES["userfile"]["tmp_name"])) {
 
 		emr_delete_current_files($current_file);
 
+		// Massage new filename to adhere to WordPress standards
+		$new_filename= wp_unique_filename( $current_path, $new_filename );
+
 		// Move new file to old location, new name
 		$new_file = $current_path . "/" . $new_filename;
 		move_uploaded_file($_FILES["userfile"]["tmp_name"], $new_file);

--- a/upload.php
+++ b/upload.php
@@ -206,9 +206,6 @@ if (is_uploaded_file($_FILES["userfile"]["tmp_name"])) {
 
 		emr_delete_current_files($current_file);
 
-		// Massage new filename to adhere to WordPress standards
-		$new_filename= wp_unique_filename( $current_path, $new_filename );
-
 		// Move new file to old location, new name
 		$new_file = $current_path . "/" . $new_filename;
 		move_uploaded_file($_FILES["userfile"]["tmp_name"], $new_file);


### PR DESCRIPTION
This addresses [DFCT2000208](https://bu.service-now.com/rm_defect.do?sysparm_tiny=e1dd14dd8791a95018577408dabb3545&sys_id=53b0a95b877e29d018577408dabb35b3&sysparm_record_row=18) 
When trying to replace an item in the Media Library (with the Enable Media Replace plugin), it's not actually keeping the same filename, but rather is giving a new name with a suffix (e.g., "huge.jpg" becomes "huge-1.jpg").

The wrong condition was getting triggered because the form was not getting sent with the parameter  `replace_type` = 'replace'
https://github.com/bu-ist/bu-enable-media-replace/blob/c2fa654b27ec75b12c81c54f519c22c951140661/popup.php#L53C2-L67C16
`<?php if ($method == EMR_METHOD_BOTH): ?>`
                <p><?php echo __("Select media replacement type:", "enable-media-replace"); ?></p>
                <label for="replace_type_1"><input CHECKED id="replace_type_1" type="radio" name="replace_type" value="replace"> <?php echo __("Just replace the file", "enable-media-replace"); ?></label>
                <p class="howto"><?php echo __("Note: This option requires you to upload a file of the same type (", "enable-media-replace"); ?><?php echo $current_filetype; ?><?php echo __(") as the one you are replacing. The name of the attachment will stay the same (", "enable-media-replace"); ?><?php echo $current_filename; ?><?php echo __(") no matter what the file you upload is called.", "enable-media-replace"); ?></p>

                <label for="replace_type_2"><input id="replace_type_2" type="radio" name="replace_type" value="replace_and_search"> <?php echo __("Replace the file, use new file name and update all links", "enable-media-replace"); ?></label>
                <p class="howto"><?php echo __("Note: If you check this option, the name and type of the file you are about to upload will replace the old file. All links pointing to the current file (", "enable-media-replace"); ?><?php echo $current_filename; ?><?php echo __(") will be updated to point to the new file name.", "enable-media-replace"); ?></p>
        <?php elseif ($method == EMR_METHOD_REPLACE): ?>
                <p><?php echo __("<strong>Replacement method:</strong> ", "enable-media-replace");  echo __("Just replace the file", "enable-media-replace"); ?></p>
                <p class="howto"><?php echo __("Note: This method requires you to upload a file of the same type (", "enable-media-replace"); ?><?php echo $current_filetype; ?><?php echo __(") as the one you are replacing. The name of the attachment will stay the same (", "enable-media-replace"); ?><?php echo $current_filename; ?><?php echo __(") no matter what the file you upload is called.", "enable-media-replace"); ?></p>
        <?php elseif ($method == EMR_METHOD_REPLACE_AND_RENAME): ?>
                <p><?php echo __("<strong>Replacement method:</strong> ", "enable-media-replace");  echo __("Replace the file, use new file name and update all links", "enable-media-replace"); ?></label>
                <p class="howto"><?php echo __("Note: If you check this option, the name and type of the file you are about to upload will replace the old file. All links pointing to the current file (", "enable-media-replace"); ?><?php echo $current_filename; ?><?php echo __(") will be updated to point to the new file name.", "enable-media-replace"); ?></p>
`<?php endif;?>`
The solution here is to change `EMR_METHOD` to 'EMR_METHOD_BOTH' so that the UI displays the option for replacing the file and includes the correct parameter. 